### PR TITLE
jupiter-1 Research spike: schema validation of xAPI payloads

### DIFF
--- a/src/main/resources/xapi/data/statement-0.9.json
+++ b/src/main/resources/xapi/data/statement-0.9.json
@@ -1,0 +1,58 @@
+{
+    "id": "d1eec41f-1e93-4ed6-acbf-5c4bd0c24269",
+    "actor": {
+        "objectType": "Person",
+        "name": [
+            "Joe Schmoe",
+            "Joseph Schmoseph"
+        ],
+        "mbox": [
+            "mailto:joe@example.com"
+        ],
+        "openid": [
+            "http://openid.com/joe-schmoe"
+        ]
+    },
+    "verb": "completed",
+    "inProgress": false,
+    "object": {
+        "objectType": "Activity",
+        "id": "http://www.example.com/activities/001",
+        "definition": {
+            "name": {
+                "en-US": "Example Activity"
+            },
+            "type": "course"
+        }
+    },
+    "result": {
+        "completion": true
+    },
+    "context": {
+        "instructor": {
+            "objectType": "Person",
+            "lastName": [
+                "Dad"
+            ],
+            "firstName": [
+                "Joe's"
+            ],
+            "mbox": [
+                "mailto:joesdad@example.com"
+            ]
+        },
+        "contextActivities": {
+            "parent": {
+                "objectType": "Activity",
+                "id": "non-absolute-activity-id",
+                "definition": {
+                    "name": {
+                        "en-US": "Another Activity"
+                    }
+                }
+            }
+        }
+    },
+    "timestamp": "2012-06-01T19:09:13.245Z",
+    "stored": "2012-06-29T15:41:39.165Z"
+}

--- a/src/main/resources/xapi/data/statement-bad-objecttype.json
+++ b/src/main/resources/xapi/data/statement-bad-objecttype.json
@@ -1,0 +1,56 @@
+{
+    "version": "1.0.0",
+    "id": "d1eec41f-1e93-4ed6-acbf-5c4bd0c24269",
+    "actor": {
+        "objectType": "Agent",
+        "name": "Joe Schmoe",
+        "mbox": "mailto:joe@example.com"
+    },
+    "verb": {
+        "id": "http://adlnet.gov/expapi/verbs/completed",
+        "display": {
+            "en-US": "completed"
+        }
+    },
+    "object": {
+        "objectType": "Activities",
+        "id": "http://www.example.com/activities/001",
+        "definition": {
+            "name": {
+                "en-US": "Example Activity"
+            },
+            "type": "http://adlnet.gov/expapi/activities/course"
+        }
+    },
+    "result": {
+        "completion": true
+    },
+    "context": {
+        "instructor": {
+            "objectType": "Agent",
+            "mbox": "mailto:joesdad@example.com"
+        },
+        "contextActivities": {
+            "parent": [
+                {
+                    "objectType": "Activity",
+                    "id": "tag:adlnet.gov,2013:expapi:0.9:activities:non-absolute-activity-id",
+                    "definition": {
+                        "name": {
+                            "en-US": "Another Activity"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "timestamp": "2012-06-01T19:09:13.245Z",
+    "stored": "2012-06-29T15:41:39.165Z",
+    "authority": {
+        "objectType": "Agent",
+        "account": {
+            "homePage": "http://www.example.com",
+            "name": "unknown"
+        }
+    }
+}

--- a/src/main/resources/xapi/data/statement1.json
+++ b/src/main/resources/xapi/data/statement1.json
@@ -1,0 +1,25 @@
+{
+    "id" : "fd41c918-b88b-4b20-a0a5-a4c32391aaa0",
+    "actor" : {
+        "objectType" : "Blowup",
+        "name" : "Project Tin Can API",
+        "mbox" : "mailto:user@example.com"
+    },
+    "verb" : {
+        "id" : "http://adlnet.gov/expapi/verbs/created",
+        "display" : {
+            "en-US" : "created"
+        }
+    },
+    "object" : {
+        "id" : "http://example.adlnet.gov/xapi/example/simplestatement",
+        "definition" : {
+            "name" : {
+                "en-US" : "simple statement"
+            },
+            "description" : {
+                "en-US" : "A simple Experience API statement. Note that the LRS does not need to have any prior information about the Actor (learner), the verb, or the Activity/object."
+            }
+        }
+    }
+}

--- a/src/main/resources/xapi/data/statement2.json
+++ b/src/main/resources/xapi/data/statement2.json
@@ -1,0 +1,31 @@
+{
+    "actor":{
+        "objectType": "Agent",
+        "name":"Example Learner",
+        "mbox":"mailto:example.learner@adlnet.gov"
+    },
+    "verb":{
+        "id":"http://adlnet.gov/expapi/verbs/attempted",
+        "display":{
+            "en-US":"attempted"
+        }
+    },
+    "object":{
+        "id":"http://example.adlnet.gov/xapi/example/simpleCBT",
+        "definition":{
+            "name":{
+                "en-US":"simple CBT course"
+            },
+            "description":{
+                "en-US":"A fictitious example CBT course."
+            }
+        }
+    },
+    "result":{
+        "score":{
+            "scaled":0.95
+        },
+        "success":true,
+        "completion":true
+    }
+}

--- a/src/main/resources/xapi/data/statement3.json
+++ b/src/main/resources/xapi/data/statement3.json
@@ -1,0 +1,131 @@
+{
+    "id": "6690e6c9-3ef0-4ed3-8b37-7f3964730bee",
+    "actor": {
+        "name": "Team PB",
+        "mbox": "mailto:teampb@example.com",
+        "member": [
+            {
+                "name": "Andrew Downes",
+                "account": {
+                    "homePage": "http://www.example.com",
+                    "name": "13936749"
+                },
+                "objectType": "Agent"
+            },
+            {
+                "name": "Toby Nichols",
+                "openid": "http://toby.openid.example.org/",
+                "objectType": "Agent"
+            },
+            {
+                "name": "Ena Hills",
+                "mbox_sha1sum": "ebd31e95054c018b10727ccffd2ef2ec3a016ee9",
+                "objectType": "Agent"
+            }
+        ],
+        "objectType": "Group"
+    },
+    "verb": {
+        "id": "http://adlnet.gov/expapi/verbs/attended",
+        "display": {
+            "en-GB": "attended",
+            "en-US": "attended"
+        }
+    },
+    "result": {
+        "extensions": {
+            "http://example.com/profiles/meetings/resultextensions/minuteslocation": "X:\\meetings\\minutes\\examplemeeting.one"
+        },
+        "success": true,
+        "completion": true,
+        "response": "We agreed on some example actions.",
+        "duration": "PT1H0M0S"
+    },
+    "context": {
+        "registration": "ec531277-b57b-4c15-8d91-d292c5b2b8f7",
+        "contextActivities": {
+            "parent": [
+                {
+                    "id": "http://www.example.com/meetings/series/267",
+                    "objectType": "Activity"
+                }
+            ],
+            "category": [
+                {
+                    "id": "http://www.example.com/meetings/categories/teammeeting",
+                    "objectType": "Activity",
+                    "definition": {
+                        "name": {
+                            "en": "team meeting"
+                        },
+                        "description": {
+                            "en": "A category of meeting used for regular team meetings."
+                        },
+                        "type": "http://example.com/expapi/activities/meetingcategory"
+                    }
+                }
+            ],
+            "other": [
+                {
+                    "id": "http://www.example.com/meetings/occurances/34257",
+                    "objectType": "Activity"
+                },
+                {
+                    "id": "http://www.example.com/meetings/occurances/3425567",
+                    "objectType": "Activity"
+                }
+            ]
+        },
+        "instructor" :
+        {
+            "name": "Andrew Downes",
+            "account": {
+                "homePage": "http://www.example.com",
+                "name": "13936749"
+            },
+            "objectType": "Agent"
+        },
+        "team":
+        {
+            "name": "Team PB",
+            "mbox": "mailto:teampb@example.com",
+            "objectType": "Group"
+        },
+        "platform" : "Example virtual meeting software",
+        "language" : "tlh",
+        "statement" : {
+            "objectType":"StatementRef",
+            "id" :"6690e6c9-3ef0-4ed3-8b37-7f3964730bee"
+        }
+
+    },
+    "timestamp": "2013-05-18T05:32:34.804Z",
+    "stored": "2013-05-18T05:32:34.804Z",
+    "authority": {
+        "account": {
+            "homePage": "http://cloud.scorm.com/",
+            "name": "anonymous"
+        },
+        "objectType": "Agent"
+    },
+    "version": "1.0.0",
+    "object": {
+        "id": "http://www.example.com/meetings/occurances/34534",
+        "definition": {
+            "extensions": {
+                "http://example.com/profiles/meetings/activitydefinitionextensions/room": {"name": "Kilby", "id" : "http://example.com/rooms/342"}
+            },
+            "name": {
+                "en-GB": "example meeting",
+                "en-US": "example meeting"
+            },
+            "description": {
+                "en-GB": "An example meeting that happened on a specific occasion with certain people present.",
+                "en-US": "An example meeting that happened on a specific occasion with certain people present."
+            },
+            "type": "http://adlnet.gov/expapi/activities/meeting",
+            "moreInfo": "http://virtualmeeting.example.com/345256"
+        },
+        "objectType": "Activity"
+    }
+}

--- a/src/main/resources/xapi/data/statement4.json
+++ b/src/main/resources/xapi/data/statement4.json
@@ -1,0 +1,56 @@
+{
+    "version": "1.0.0",
+    "id": "d1eec41f-1e93-4ed6-acbf-5c4bd0c24269",
+    "actor": {
+        "objectType": "Agent",
+        "name": "Joe Schmoe",
+        "mbox": "mailto:joe@example.com"
+    },
+    "verb": {
+        "id": "http://adlnet.gov/expapi/verbs/completed",
+        "display": {
+            "en-US": "completed"
+        }
+    },
+    "object": {
+        "objectType": "Activity",
+        "id": "http://www.example.com/activities/001",
+        "definition": {
+            "name": {
+                "en-US": "Example Activity"
+            },
+            "type": "http://adlnet.gov/expapi/activities/course"
+        }
+    },
+    "result": {
+        "completion": true
+    },
+    "context": {
+        "instructor": {
+            "objectType": "Agent",
+            "mbox": "mailto:joesdad@example.com"
+        },
+        "contextActivities": {
+            "parent": [
+                {
+                    "objectType": "Activity",
+                    "id": "tag:adlnet.gov,2013:expapi:0.9:activities:non-absolute-activity-id",
+                    "definition": {
+                        "name": {
+                            "en-US": "Another Activity"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "timestamp": "2012-06-01T19:09:13.245Z",
+    "stored": "2012-06-29T15:41:39.165Z",
+    "authority": {
+        "objectType": "Agent",
+        "account": {
+            "homePage": "http://www.example.com",
+            "name": "unknown"
+        }
+    }
+}

--- a/src/main/resources/xapi/schemas/test.js
+++ b/src/main/resources/xapi/schemas/test.js
@@ -1,0 +1,547 @@
+var statement = {
+    "id" : "fd41c918-b88b-4b20-a0a5-a4c32391aaa0",
+    "actor" : {
+        "objectType" : "Blowup",
+        "name" : "Project Tin Can API",
+        "mbox" : "mailto:user@example.com"
+    },
+    "verb" : {
+        "id" : "http://adlnet.gov/expapi/verbs/created",
+        "display" : {
+            "en-US" : "created"
+        }
+    },
+    "object" : {
+        "id" : "http://example.adlnet.gov/xapi/example/simplestatement",
+        "definition" : {
+            "name" : {
+                "en-US" : "simple statement"
+            },
+            "description" : {
+                "en-US" : "A simple Experience API statement. Note that the LRS does not need to have any prior information about the Actor (learner), the verb, or the Activity/object."
+            }
+        }
+    }
+};
+var schema = {
+    "properties" : {
+        "uuid" : {
+            "id" : "#uuid",
+            "type" : "string",
+            "pattern" : "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{8}"
+        },
+        "mbox" : {
+            "id" : "#mbox",
+            "type" : "object",
+            "properties" : {
+                "mbox" : {
+                    "required" : true,
+                    "type" : "string",
+                    "format" : "uri",
+                    "pattern" : "^mailto:"
+                }
+            },
+            "patternProperties" : {
+                "^(mbox_sha1sum|account|openid)$" : {
+                    "type" : "null"
+                }
+            }
+        },
+        "mbox_sha1sum" : {
+            "id" : "#mbox_sha1sum",
+            "type" : "object",
+            "properties" : {
+                "mbox_sha1sum" : {
+                    "required" : true,
+                    "type" : "string"
+                }
+            },
+            "patternProperties" : {
+                "^(mbox|account|openid)$" : {
+                    "type" : "null"
+                }
+            }
+        },
+        "account" : {
+            "id" : "#account",
+            "type" : "object",
+            "properties" : {
+                "account" : {
+                    "required" : true,
+                    "type" : "object",
+                    "properties" : {
+                        "homePage" : {
+                            "type" : "string",
+                            "format" : "uri",
+                            "required" : true
+                        },
+                        "name" : {
+                            "type" : "string",
+                            "required" : true
+                        }
+                    },
+                    "additionalProperties" : false
+                }
+            },
+            "patternProperties" : {
+                "^(mbox_sha1sum|mbox|openid)$" : {
+                    "type" : "null"
+                }
+            }
+        },
+        "openid" : {
+            "id" : "#openid",
+            "type" : "object",
+            "properties" : {
+                "openid" : {
+                    "required" : true,
+                    "type" : "string",
+                    "format" : "uri"
+                }
+            },
+            "patternProperties" : {
+                "^(mbox_sha1sum|account|mbox)$" : {
+                    "type" : "null"
+                }
+            }
+        },
+        "inversefunctional" : {
+            "id" : "#inversefunctional",
+            "type" : [
+                {
+                    "$ref" : "#mbox"
+                },
+                {
+                    "$ref" : "#mbox_sha1sum"
+                },
+                {
+                    "$ref" : "#account"
+                },
+                {
+                    "$ref" : "#openid"
+                }
+            ]
+        },
+        "agent" : {
+            "id" : "#agent",
+            "type" : [
+                {
+                    "$ref" : "#inversefunctional"
+                }
+            ],
+            "properties" : {
+                "name" : {
+                    "type" : "string"
+                },
+                "objectType" : {
+                    "enum" : ["Agent"]
+                },
+                "mbox" : {},
+                "mbox_sha1sum" : {},
+                "account" : {},
+                "openid" : {}
+            },
+            "additionalProperties" : false
+        },
+        "groupBasics" : {
+            "id" : "#groupBasics",
+            "type" : "object",
+            "properties" : {
+                "name" : {
+                    "type" : "string"
+                },
+                "objectType" : {
+                    "enum" : ["Group"],
+                    "required" : true
+                },
+                "member" : {
+                    "type" : "array",
+                    "items" : {
+                        "$ref" : "#agent"
+                    }
+                }
+            }
+        },
+        "anonymousgroup" : {
+            "id" : "#anonymousgroup",
+            "properties" : {
+                "member" : {
+                    "required" : true
+                },
+                "name" : {},
+                "objectType" : {}
+            },
+            "additionalProperties" : false
+        },
+        "identifiedgroup" : {
+            "id" : "#identifiedgroup",
+            "extends" : {
+                "$ref" : "#inversefunctional"
+            },
+            "properties" : {
+                "name" : {},
+                "objectType" : {},
+                "member" : {},
+                "mbox" : {},
+                "mbox_sha1sum" : {},
+                "account" : {},
+                "openid" : {}
+            },
+            "additionalProperties" : false
+        },
+        "group" : {
+            "id" : "#group",
+            "extends" : {
+                "$ref" : "#groupBasics"
+            },
+            "type" : [
+                {
+                    "$ref" : "#anonymousgroup"
+                },
+                {
+                    "$ref" : "#identifiedgroup"
+                }
+            ]
+        },
+        "languagemap" : {
+            "id" : "#languagemap",
+            "type" : "object",
+            "patternProperties" : {
+                "^(([a-zA-Z]{2,8}((-[a-zA-Z]{3}){0,3})(-[a-zA-Z]{4})?((-[a-zA-Z]{2})|(-\\d{3}))?(-[a-zA-Z\\d]{4,8})*(-[a-zA-Z\\d](-[a-zA-Z\\d]{1,8})+)*)|x(-[a-zA-Z\\d]{1,8})+|en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tsu|i-tay|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)$" : {
+                    "type" : "string"
+                }
+            },
+            "additionalProperties" : false
+        },
+        "extensions" : {
+            "id" : "#extensions",
+            "patternProperties" : {
+                "^[a-zA-Z][a-zA-Z+.-]*:" : {
+                    "type" : "any"
+                }
+            },
+            "additionalProperties" : false
+        },
+        "activity" : {
+            "id" : "#activity",
+            "type" : "object",
+            "properties" : {
+                "id" : {
+                    "type" : "string",
+                    "format" : "uri",
+                    "required" : true
+                },
+                "objectType" : {
+                    "enum" : ["Activity"]
+                },
+                "definition" : {
+                    "type" : "object",
+                    "properties" : {
+                        "name" : {
+                            "$ref" : "#languagemap"
+                        },
+                        "description" : {
+                            "$ref" : "#languagemap"
+                        },
+                        "type" : {
+                            "type" : "string",
+                            "format" : "uri"
+                        },
+                        "interactionType" : {
+                            "enum" : [
+                                "true-false",
+                                "choice",
+                                "fill-in",
+                                "long-fill-in",
+                                "matching",
+                                "performance",
+                                "sequencing",
+                                "likert",
+                                "numeric",
+                                "other"
+                            ]
+                        },
+                        "correctResponsesPattern" : {
+                            "type" : "array",
+                            "items" : {
+                                "type" : "string"
+                            }
+                        },
+                        "extensions" : {
+                            "$ref" : "#extensions"
+                        }
+                    },
+                    "patternProperties" : {
+                        "^(choices|scale|source|target|steps)$" : {
+                            "type" : "object",
+                            "properties" : {
+                                "id" : {
+                                    "type" : "string",
+                                    "required" : true
+                                },
+                                "description" : {
+                                    "$ref" : "#languagemap"
+                                }
+                            },
+                            "additionalProperties" : false
+                        }
+                    },
+                    "additionalProperties" : false
+                }
+            },
+            "additionalProperties" : false
+        },
+        "objectagent" : {
+            "id" : "#objectagent",
+            "type" : [
+                {
+                    "$ref" : "#agent"
+                }
+            ],
+            "properties" : {
+                "objectType" : {
+                    "required" : true
+                }
+            }
+        },
+        "statementref" : {
+            "id" : "#statementref",
+            "type" : "object",
+            "properties" : {
+                "objectType" : {
+                    "enum" : ["StatementRef"],
+                    "required" : true
+                },
+                "id" : {
+                    "type" : [
+                        {
+                            "$ref" : "#uuid"
+                        }
+                    ],
+                    "required" : true
+                }
+            },
+            "additionalProperties" : false
+        },
+        "substatement" : {
+            "id" : "#substatement",
+            "type" : [
+                {
+                    "$ref" : "#statement"
+                }
+            ],
+            "properties" : {
+                "objectType" : {
+                    "enum" : ["SubStatement"],
+                    "required" : true
+                },
+                "object" : {
+                    "disallow" : [
+                        {
+                            "properties" : {
+                                "objectType" : {
+                                    "enum" : ["SubStatement"]
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            "patternProperties" : {
+                "^(id|stored|authority|voided)$" : {
+                    "type" : "null"
+                }
+            }
+        },
+        "statement" : {
+            "id" : "#statement",
+            "type" : "object",
+            "properties" : {
+                "id" : {
+                    "$ref" : "#uuid"
+                },
+                "actor" : {
+                    "type" : [
+                        {
+                            "$ref" : "#agent"
+                        },
+                        {
+                            "$ref" : "#group"
+                        }
+                    ],
+                    "required" : true
+                },
+                "verb" : {
+                    "required" : true,
+                    "type" : "object",
+                    "properties" : {
+                        "id" : {
+                            "required" : true,
+                            "type" : "string",
+                            "format" : "uri"
+                        },
+                        "display" : {
+                            "$ref" : "#languagemap"
+                        }
+                    },
+                    "additionalProperties" : false
+                },
+                "object" : {
+                    "type" : [
+                        {
+                            "$ref" : "#activity"
+                        },
+                        {
+                            "$ref" : "#objectagent"
+                        },
+                        {
+                            "$ref" : "#group"
+                        },
+                        {
+                            "$ref" : "#statementref"
+                        },
+                        {
+                            "$ref" : "#substatement"
+                        }
+                    ],
+                    "required" : true
+                },
+                "objectType" : {},
+                "result" : {
+                    "type" : "object",
+                    "properties" : {
+                        "score" : {
+                            "type" : "object",
+                            "properties" : {
+                                "scaled" : {
+                                    "type" : "number",
+                                    "minimum" : 0,
+                                    "maximum" : 1
+                                },
+                                "raw" : {
+                                    "type" : "number"
+                                },
+                                "min" : {
+                                    "type" : "number"
+                                },
+                                "max" : {
+                                    "type" : "number"
+                                }
+                            }
+                        },
+                        "success" : {
+                            "type" : "boolean"
+                        },
+                        "completion" : {
+                            "type" : "boolean"
+                        },
+                        "response" : {
+                            "type" : "string"
+                        },
+                        "duration" : {
+                            "type" : "string"
+                        },
+                        "extensions" : {
+                            "$ref" : "#extensions"
+                        }
+                    },
+                    "additionalProperties" : false
+                },
+                "context" : {
+                    "type" : "object",
+                    "properties" : {
+                        "registration" : {
+                            "$ref" : "#uuid"
+                        },
+                        "instructor" : {
+                            "type" : [
+                                {
+                                    "$ref" : "#agent"
+                                },
+                                {
+                                    "$ref" : "#group"
+                                }
+                            ]
+                        },
+                        "team" : {
+                            "type" : [
+                                {
+                                    "$ref" : "#agent"
+                                },
+                                {
+                                    "$ref" : "#group"
+                                }
+                            ]
+                        },
+                        "contextActivities" : {
+                            "type" : "object",
+                            "properties" : {
+                                "parent" : {
+                                    "$ref" : "#activity"
+                                },
+                                "grouping" : {
+                                    "$ref" : "#activity"
+                                },
+                                "other" : {
+                                    "$ref" : "#activity"
+                                }
+                            },
+                            "additionalProperties" : false
+                        },
+                        "revision" : {
+                            "type" : "string"
+                        },
+                        "platform" : {
+                            "type" : "string"
+                        },
+                        "language" : {
+                            "type" : "string"
+                        },
+                        "statement" : {
+                            "$ref" : "#statementref"
+                        },
+                        "extensions" : {
+                            "$ref" : "#extensions"
+                        }
+                    },
+                    "additionalProperties" : false
+                },
+                "timestamp" : {
+                    "type" : "string"
+                },
+                "stored" : {
+                    "type" : "string"
+                },
+                "authority" : {
+                    "type" : [
+                        {
+                            "$ref" : "#agent"
+                        },
+                        {
+                            "type" : [
+                                {
+                                    "$ref" : "#anonymousgroup"
+                                }
+                            ],
+                            "properties" : {
+                                "member" : {
+                                    "type" : "array",
+                                    "minItems" : 2,
+                                    "maxItems" : 2
+                                }
+                            }
+                        }
+                    ]
+                },
+                "voided" : {
+                    "type" : "boolean"
+                }
+            },
+            "additionalProperties" : false
+        }
+    }
+};
+
+var ZSchema = require("z-schema");
+var z = new ZSchema();
+z.validate( statement, schema );

--- a/src/main/resources/xapi/schemas/xapi-0.9.5-revised.schema
+++ b/src/main/resources/xapi/schemas/xapi-0.9.5-revised.schema
@@ -1,0 +1,514 @@
+{
+    "properties" : {
+        "uuid" : {
+            "id" : "uuid",
+            "type" : "string",
+            "pattern" : "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{8}"
+        },
+        "mbox" : {
+            "id" : "mbox",
+            "type" : "object",
+            "properties" : {
+                "mbox" : {
+                    "required" : true,
+                    "type" : "string",
+                    "format" : "uri",
+                    "pattern" : "^mailto:"
+                }
+            },
+            "patternProperties" : {
+                "^(mbox_sha1sum|account|openid)$" : {
+                    "type" : "null"
+                }
+            }
+        },
+        "mbox_sha1sum" : {
+            "id" : "mbox_sha1sum",
+            "type" : "object",
+            "properties" : {
+                "mbox_sha1sum" : {
+                    "required" : true,
+                    "type" : "string"
+                }
+            },
+            "patternProperties" : {
+                "^(mbox|account|openid)$" : {
+                    "type" : "null"
+                }
+            }
+        },
+        "account" : {
+            "id" : "account",
+            "type" : "object",
+            "properties" : {
+                "account" : {
+                    "type" : "object",
+                    "properties" : {
+                        "homePage" : {
+                            "type" : "string",
+                            "format" : "uri"
+                        },
+                        "name" : {
+                            "type" : "string"
+                        }
+                    },
+                    "required" : ["homepage", "name"],
+                    "additionalProperties" : false
+                }
+            },
+            "required": ["account"],
+            "patternProperties" : {
+                "^(mbox_sha1sum|mbox|openid)$" : {
+                    "type" : "null"
+                }
+            }
+        },
+        "openid" : {
+            "id" : "openid",
+            "type" : "object",
+            "properties" : {
+                "openid" : {
+                    "type" : "string",
+                    "format" : "uri"
+                }
+            },
+            "required" : ["openid"],
+            "patternProperties" : {
+                "^(mbox_sha1sum|account|mbox)$" : {
+                    "type" : "null"
+                }
+            }
+        },
+        "inversefunctional" : {
+            "id" : "inversefunctional",
+            "type" : [
+                {
+                    "$ref" : "#mbox"
+                },
+                {
+                    "$ref" : "#mbox_sha1sum"
+                },
+                {
+                    "$ref" : "#account"
+                },
+                {
+                    "$ref" : "#openid"
+                }
+            ]
+        },
+        "agent" : {
+            "id" : "agent",
+            "type" : [
+                {
+                    "$ref" : "#inversefunctional"
+                }
+            ],
+            "properties" : {
+                "name" : {
+                    "type" : "string"
+                },
+                "objectType" : {
+                    "enum" : ["Agent"]
+                },
+                "mbox" : {},
+                "mbox_sha1sum" : {},
+                "account" : {},
+                "openid" : {}
+            },
+            "additionalProperties" : false
+        },
+        "groupBasics" : {
+            "id" : "groupBasics",
+            "type" : "object",
+            "properties" : {
+                "name" : {
+                    "type" : "string"
+                },
+                "objectType" : {
+                    "enum" : ["Group"]
+                },
+                "member" : {
+                    "type" : "array",
+                    "items" : {
+                        "$ref" : "#agent"
+                    }
+                }
+            },
+            "required" : ["objectType"]
+        },
+        "anonymousgroup" : {
+            "id" : "anonymousgroup",
+            "properties" : {
+                "member" : {
+                },
+                "name" : {},
+                "objectType" : {}
+            },
+            "required" : ["member"],
+            "additionalProperties" : false
+        },
+        "identifiedgroup" : {
+            "id" : "identifiedgroup",
+            "extends" : {
+                "$ref" : "#inversefunctional"
+            },
+            "properties" : {
+                "name" : {},
+                "objectType" : {},
+                "member" : {},
+                "mbox" : {},
+                "mbox_sha1sum" : {},
+                "account" : {},
+                "openid" : {}
+            },
+            "additionalProperties" : false
+        },
+        "group" : {
+            "id" : "group",
+            "extends" : {
+                "$ref" : "#groupBasics"
+            },
+            "type" : [
+                {
+                    "$ref" : "#anonymousgroup"
+                },
+                {
+                    "$ref" : "#identifiedgroup"
+                }
+            ]
+        },
+        "languagemap" : {
+            "id" : "languagemap",
+            "type" : "object",
+            "patternProperties" : {
+                "^(([a-zA-Z]{2,8}((-[a-zA-Z]{3}){0,3})(-[a-zA-Z]{4})?((-[a-zA-Z]{2})|(-\\d{3}))?(-[a-zA-Z\\d]{4,8})*(-[a-zA-Z\\d](-[a-zA-Z\\d]{1,8})+)*)|x(-[a-zA-Z\\d]{1,8})+|en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tsu|i-tay|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)$" : {
+                    "type" : "string"
+                }
+            },
+            "additionalProperties" : false
+        },
+        "extensions" : {
+            "id" : "extensions",
+            "patternProperties" : {
+                "^[a-zA-Z][a-zA-Z+.-]*:" : {
+                    "type" : "any"
+                }
+            },
+            "additionalProperties" : false
+        },
+        "activity" : {
+            "id" : "activity",
+            "type" : "object",
+            "properties" : {
+                "id" : {
+                    "type" : "string",
+                    "format" : "uri"
+                },
+                "objectType" : {
+                    "enum" : ["Activity"]
+                },
+                "definition" : {
+                    "type" : "object",
+                    "properties" : {
+                        "name" : {
+                            "$ref" : "#languagemap"
+                        },
+                        "description" : {
+                            "$ref" : "#languagemap"
+                        },
+                        "type" : {
+                            "type" : "string",
+                            "format" : "uri"
+                        },
+                        "interactionType" : {
+                            "enum" : [
+                                "true-false",
+                                "choice",
+                                "fill-in",
+                                "long-fill-in",
+                                "matching",
+                                "performance",
+                                "sequencing",
+                                "likert",
+                                "numeric",
+                                "other"
+                            ]
+                        },
+                        "correctResponsesPattern" : {
+                            "type" : "array",
+                            "items" : {
+                                "type" : "string"
+                            }
+                        },
+                        "extensions" : {
+                            "$ref" : "#extensions"
+                        }
+                    },
+                    "patternProperties" : {
+                        "^(choices|scale|source|target|steps)$" : {
+                            "type" : "object",
+                            "properties" : {
+                                "id" : {
+                                    "type" : "string"
+                                },
+                                "description" : {
+                                    "$ref" : "#languagemap"
+                                }
+                            },
+                            "required" : ["id"],
+                            "additionalProperties" : false
+                        }
+                    },
+                    "additionalProperties" : false
+                }
+            },
+            "required" : ["id"],
+            "additionalProperties" : false
+        },
+        "objectagent" : {
+            "id" : "objectagent",
+            "type" : [
+                {
+                    "$ref" : "#agent"
+                }
+            ],
+            "properties" : {
+                "objectType" : {
+                },
+                "required" : ["objectType"]
+            }
+        },
+        "statementref" : {
+            "id" : "statementref",
+            "type" : "object",
+            "properties" : {
+                "objectType" : {
+                    "enum" : ["StatementRef"]
+                },
+                "id" : {
+                    "type" : [
+                        {
+                            "$ref" : "#uuid"
+                        }
+                    ]
+                }
+            },
+            "required" : ["id", "objectType"],
+            "additionalProperties" : false
+        },
+        "substatement" : {
+            "id" : "substatement",
+            "type" : [
+                {
+                    "$ref" : "#statement"
+                }
+            ],
+            "properties" : {
+                "objectType" : {
+                    "enum" : ["SubStatement"]
+                },
+                "object" : {
+                    "disallow" : [
+                        {
+                            "properties" : {
+                                "objectType" : {
+                                    "enum" : ["SubStatement"]
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            "required" : ["objectType"],
+            "patternProperties" : {
+                "^(id|stored|authority|voided)$" : {
+                    "type" : "null"
+                }
+            }
+        },
+        "statement" : {
+            "id" : "statement",
+            "type" : "object",
+            "properties" : {
+                "id" : {
+                    "$ref" : "#uuid"
+                },
+                "actor" : {
+                    "type" : [
+                        {
+                            "$ref" : "#agent"
+                        },
+                        {
+                            "$ref" : "#group"
+                        }
+                    ]
+                },
+                "verb" : {
+                    "type" : "object",
+                    "properties" : {
+                        "id" : {
+                            "type" : "string",
+                            "format" : "uri"
+                        },
+                        "display" : {
+                            "$ref" : "#languagemap"
+                        }
+                    },
+                    "required" : ["id"],
+                    "additionalProperties" : false
+                },
+                "object" : {
+                    "type" : [
+                        {
+                            "$ref" : "#activity"
+                        },
+                        {
+                            "$ref" : "#objectagent"
+                        },
+                        {
+                            "$ref" : "#group"
+                        },
+                        {
+                            "$ref" : "#statementref"
+                        },
+                        {
+                            "$ref" : "#substatement"
+                        }
+                    ]
+                },
+                "objectType" : {},
+                "result" : {
+                    "type" : "object",
+                    "properties" : {
+                        "score" : {
+                            "type" : "object",
+                            "properties" : {
+                                "scaled" : {
+                                    "type" : "number",
+                                    "minimum" : 0,
+                                    "maximum" : 1
+                                },
+                                "raw" : {
+                                    "type" : "number"
+                                },
+                                "min" : {
+                                    "type" : "number"
+                                },
+                                "max" : {
+                                    "type" : "number"
+                                }
+                            }
+                        },
+                        "success" : {
+                            "type" : "boolean"
+                        },
+                        "completion" : {
+                            "type" : "boolean"
+                        },
+                        "response" : {
+                            "type" : "string"
+                        },
+                        "duration" : {
+                            "type" : "string"
+                        },
+                        "extensions" : {
+                            "$ref" : "#extensions"
+                        }
+                    },
+                    "additionalProperties" : false
+                },
+                "context" : {
+                    "type" : "object",
+                    "properties" : {
+                        "registration" : {
+                            "$ref" : "#uuid"
+                        },
+                        "instructor" : {
+                            "type" : [
+                                {
+                                    "$ref" : "#agent"
+                                },
+                                {
+                                    "$ref" : "#group"
+                                }
+                            ]
+                        },
+                        "team" : {
+                            "type" : [
+                                {
+                                    "$ref" : "#agent"
+                                },
+                                {
+                                    "$ref" : "#group"
+                                }
+                            ]
+                        },
+                        "contextActivities" : {
+                            "type" : "object",
+                            "properties" : {
+                                "parent" : {
+                                    "$ref" : "#activity"
+                                },
+                                "grouping" : {
+                                    "$ref" : "#activity"
+                                },
+                                "other" : {
+                                    "$ref" : "#activity"
+                                }
+                            },
+                            "additionalProperties" : false
+                        },
+                        "revision" : {
+                            "type" : "string"
+                        },
+                        "platform" : {
+                            "type" : "string"
+                        },
+                        "language" : {
+                            "type" : "string"
+                        },
+                        "statement" : {
+                            "$ref" : "#statementref"
+                        },
+                        "extensions" : {
+                            "$ref" : "#extensions"
+                        }
+                    },
+                    "additionalProperties" : false
+                },
+                "timestamp" : {
+                    "type" : "string"
+                },
+                "stored" : {
+                    "type" : "string"
+                },
+                "authority" : {
+                    "type" : [
+                        {
+                            "$ref" : "#agent"
+                        },
+                        {
+                            "type" : [
+                                {
+                                    "$ref" : "#anonymousgroup"
+                                }
+                            ],
+                            "properties" : {
+                                "member" : {
+                                    "type" : "array",
+                                    "minItems" : 2,
+                                    "maxItems" : 2
+                                }
+                            }
+                        }
+                    ]
+                },
+                "voided" : {
+                    "type" : "boolean"
+                }
+            },
+            "required" : ["actor", "verb", "object"],
+            "additionalProperties" : false
+        }
+    }
+}

--- a/src/main/resources/xapi/schemas/xapi-0.9.5.schema
+++ b/src/main/resources/xapi/schemas/xapi-0.9.5.schema
@@ -1,0 +1,532 @@
+{
+    "properties" : {
+        "uuid" : {
+            "id" : "uuid",
+            "type" : "string",
+            "pattern" : "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{8}"
+        },
+        "mbox" : {
+            "id" : "mbox",
+            "type" : "object",
+            "properties" : {
+                "mbox" : {
+                    "required" : true,
+                    "type" : "string",
+                    "format" : "uri",
+                    "pattern" : "^mailto:"
+                }
+            },
+            "patternProperties" : {
+                "^(mbox_sha1sum|account|openid)$" : {
+                    "type" : "null"
+                }
+            }
+        },
+        "mbox_sha1sum" : {
+            "id" : "mbox_sha1sum",
+            "type" : "object",
+            "properties" : {
+                "mbox_sha1sum" : {
+                    "required" : true,
+                    "type" : "string"
+                }
+            },
+            "patternProperties" : {
+                "^(mbox|account|openid)$" : {
+                    "type" : "null"
+                }
+            }
+        },
+        "account" : {
+            "id" : "account",
+            "type" : "object",
+            "properties" : {
+                "account" : {
+                    "required" : true,
+                    "type" : "object",
+                    "properties" : {
+                        "homePage" : {
+                            "type" : "string",
+                            "format" : "uri",
+                            "required" : true
+                        },
+                        "name" : {
+                            "type" : "string",
+                            "required" : true
+                        }
+                    },
+                    "additionalProperties" : false
+                }
+            },
+            "patternProperties" : {
+                "^(mbox_sha1sum|mbox|openid)$" : {
+                    "type" : "null"
+                }
+            }
+        },
+        "openid" : {
+            "id" : "openid",
+            "type" : "object",
+            "properties" : {
+                "openid" : {
+                    "required" : true,
+                    "type" : "string",
+                    "format" : "uri"
+                }
+            },
+            "patternProperties" : {
+                "^(mbox_sha1sum|account|mbox)$" : {
+                    "type" : "null"
+                }
+            }
+        },
+        "inversefunctional" : {
+            "id" : "inversefunctional",
+            "type" : [
+                {
+                    "$ref" : "#mbox"
+                },
+                {
+                    "$ref" : "#mbox_sha1sum"
+                },
+                {
+                    "$ref" : "#account"
+                },
+                {
+                    "$ref" : "#openid"
+                }
+            ]
+        },
+        "agent" : {
+            "id" : "agent",
+            "type" : [
+                {
+                    "$ref" : "#inversefunctional"
+                }
+            ],
+            "properties" : {
+                "name" : {
+                    "type" : "string"
+                },
+                "objectType" : {
+                    "enum" : ["Agent"]
+                },
+                "mbox" : {},
+                "mbox_sha1sum" : {},
+                "account" : {},
+                "openid" : {}
+            },
+            "additionalProperties" : false
+        },
+        "groupBasics" : {
+            "id" : "groupBasics",
+            "type" : "object",
+            "properties" : {
+                "name" : {
+                    "type" : "string"
+                },
+                "objectType" : {
+                    "enum" : ["Group"],
+                    "required" : true
+                },
+                "member" : {
+                    "type" : "array",
+                    "items" : {
+                        "$ref" : "#agent"
+                    }
+                }
+            }
+        },
+        "anonymousgroup" : {
+            "id" : "anonymousgroup",
+            "properties" : {
+                "member" : {
+                    "required" : true
+                },
+                "name" : {},
+                "objectType" : {}
+            },
+            "additionalProperties" : false
+        },
+        "identifiedgroup" : {
+            "id" : "identifiedgroup",
+            "extends" : {
+                "$ref" : "#inversefunctional"
+            },
+            "properties" : {
+                "name" : {},
+                "objectType" : {},
+                "member" : {},
+                "mbox" : {},
+                "mbox_sha1sum" : {},
+                "account" : {},
+                "openid" : {}
+            },
+            "additionalProperties" : false
+        },
+        "group" : {
+            "id" : "group",
+            "extends" : {
+                "$ref" : "#groupBasics"
+            },
+            "type" : [
+                {
+                    "$ref" : "#anonymousgroup"
+                },
+                {
+                    "$ref" : "#identifiedgroup"
+                }
+            ]
+        },
+        "languagemap" : {
+            "id" : "languagemap",
+            "type" : "object",
+            "patternProperties" : {
+                "^(([a-zA-Z]{2,8}((-[a-zA-Z]{3}){0,3})(-[a-zA-Z]{4})?((-[a-zA-Z]{2})|(-\\d{3}))?(-[a-zA-Z\\d]{4,8})*(-[a-zA-Z\\d](-[a-zA-Z\\d]{1,8})+)*)|x(-[a-zA-Z\\d]{1,8})+|en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tsu|i-tay|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)$" : {
+                    "type" : "string"
+                }
+            },
+            "additionalProperties" : false
+        },
+        "extensions" : {
+            "id" : "extensions",
+            "patternProperties" : {
+                "^[a-zA-Z][a-zA-Z+.-]*:" : {
+                    "type" : "any"
+                }
+            },
+            "additionalProperties" : false
+        },
+        "activity" : {
+            "id" : "activity",
+            "type" : "object",
+            "properties" : {
+                "id" : {
+                    "type" : "string",
+                    "format" : "uri",
+                    "required" : true
+                },
+                "objectType" : {
+                    "enum" : ["Activity"]
+                },
+                "definition" : {
+                    "type" : "object",
+                    "properties" : {
+                        "name" : {
+                            "$ref" : "#languagemap"
+                        },
+                        "description" : {
+                            "$ref" : "#languagemap"
+                        },
+                        "type" : {
+                            "type" : "string",
+                            "format" : "uri"
+                        },
+                        "interactionType" : {
+                            "enum" : [
+                                "true-false",
+                                "choice",
+                                "fill-in",
+                                "long-fill-in",
+                                "matching",
+                                "performance",
+                                "sequencing",
+                                "likert",
+                                "numeric",
+                                "other"
+                            ]
+                        },
+                        "correctResponsesPattern" : {
+                            "type" : "array",
+                            "items" : {
+                                "type" : "string"
+                            }
+                        },
+                        "extensions" : {
+                            "$ref" : "#extensions"
+                        }
+                    },
+                    "patternProperties" : {
+                        "^(choices|scale|source|target|steps)$" : {
+                            "type" : "object",
+                            "properties" : {
+                                "id" : {
+                                    "type" : "string",
+                                    "required" : true
+                                },
+                                "description" : {
+                                    "$ref" : "#languagemap"
+                                }
+                            },
+                            "additionalProperties" : false
+                        }
+                    },
+                    "additionalProperties" : false
+                }
+            },
+            "additionalProperties" : false
+        },
+        "objectagent" : {
+            "id" : "objectagent",
+            "type" : [
+                {
+                    "$ref" : "#agent"
+                }
+            ],
+            "properties" : {
+                "objectType" : {
+                    "required" : true
+                }
+            }
+        },
+        "statementref" : {
+            "id" : "statementref",
+            "type" : "object",
+            "properties" : {
+                "objectType" : {
+                    "enum" : ["StatementRef"],
+                    "required" : true
+                },
+                "id" : {
+                    "type" : [
+                        {
+                            "$ref" : "#uuid"
+                        }
+                    ],
+                    "required" : true
+                }
+            },
+            "additionalProperties" : false
+        },
+        "substatement" : {
+            "id" : "substatement",
+            "type" : [
+                {
+                    "$ref" : "#statement"
+                }
+            ],
+            "properties" : {
+                "objectType" : {
+                    "enum" : ["SubStatement"],
+                    "required" : true
+                },
+                "object" : {
+                    "disallow" : [
+                        {
+                            "properties" : {
+                                "objectType" : {
+                                    "enum" : ["SubStatement"]
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            "patternProperties" : {
+                "^(id|stored|authority|voided)$" : {
+                    "type" : "null"
+                }
+            }
+        },
+        "statement" : {
+            "id" : "statement",
+            "type" : "object",
+            "properties" : {
+                "id" : {
+                    "$ref" : "#uuid"
+                },
+                "actor" : {
+                    "type" : [
+                        {
+                            "$ref" : "#agent"
+                        },
+                        {
+                            "$ref" : "#group"
+                        }
+                    ],
+                    "required" : true
+                },
+                "verb" : {
+                    "required" : true,
+                    "type" : "object",
+                    "properties" : {
+                        "id" : {
+                            "required" : true,
+                            "type" : "string",
+                            "format" : "uri"
+                        },
+                        "display" : {
+                            "$ref" : "#languagemap"
+                        }
+                    },
+                    "additionalProperties" : false
+                },
+                "object" : {
+                    "type" : [
+                        {
+                            "$ref" : "#activity"
+                        },
+                        {
+                            "$ref" : "#objectagent"
+                        },
+                        {
+                            "$ref" : "#group"
+                        },
+                        {
+                            "$ref" : "#statementref"
+                        },
+                        {
+                            "$ref" : "#substatement"
+                        }
+                    ],
+                    "required" : true
+                },
+                "objectType" : {},
+                "result" : {
+                    "type" : "object",
+                    "properties" : {
+                        "score" : {
+                            "type" : "object",
+                            "properties" : {
+                                "scaled" : {
+                                    "type" : "number",
+                                    "minimum" : 0,
+                                    "maximum" : 1
+                                },
+                                "raw" : {
+                                    "type" : "number"
+                                },
+                                "min" : {
+                                    "type" : "number"
+                                },
+                                "max" : {
+                                    "type" : "number"
+                                }
+                            }
+                        },
+                        "success" : {
+                            "type" : "boolean"
+                        },
+                        "completion" : {
+                            "type" : "boolean"
+                        },
+                        "response" : {
+                            "type" : "string"
+                        },
+                        "duration" : {
+                            "type" : "string"
+                        },
+                        "extensions" : {
+                            "$ref" : "#extensions"
+                        }
+                    },
+                    "additionalProperties" : false
+                },
+                "context" : {
+                    "type" : "object",
+                    "properties" : {
+                        "registration" : {
+                            "$ref" : "#uuid"
+                        },
+                        "instructor" : {
+                            "type" : [
+                                {
+                                    "$ref" : "#agent"
+                                },
+                                {
+                                    "$ref" : "#group"
+                                }
+                            ]
+                        },
+                        "team" : {
+                            "type" : [
+                                {
+                                    "$ref" : "#agent"
+                                },
+                                {
+                                    "$ref" : "#group"
+                                }
+                            ]
+                        },
+                        "contextActivities" : {
+                            "type" : "object",
+                            "properties" : {
+                                "parent" : {
+                                    "$ref" : "#activity"
+                                },
+                                "grouping" : {
+                                    "$ref" : "#activity"
+                                },
+                                "other" : {
+                                    "$ref" : "#activity"
+                                }
+                            },
+                            "additionalProperties" : false
+                        },
+                        "revision" : {
+                            "type" : "string"
+                        },
+                        "platform" : {
+                            "type" : "string"
+                        },
+                        "language" : {
+                            "type" : "string"
+                        },
+                        "statement" : {
+                            "$ref" : "#statementref"
+                        },
+                        "extensions" : {
+                            "$ref" : "#extensions"
+                        }
+                    },
+                    "additionalProperties" : false
+                },
+                "timestamp" : {
+                    "type" : "string"
+                },
+                "stored" : {
+                    "type" : "string"
+                },
+                "authority" : {
+                    "type" : [
+                        {
+                            "$ref" : "#agent"
+                        },
+                        {
+                            "type" : [
+                                {
+                                    "$ref" : "#anonymousgroup"
+                                }
+                            ],
+                            "properties" : {
+                                "member" : {
+                                    "type" : "array",
+                                    "minItems" : 2,
+                                    "maxItems" : 2
+                                }
+                            }
+                        }
+                    ]
+                },
+                "voided" : {
+                    "type" : "boolean"
+                }
+            },
+            "additionalProperties" : false
+        },
+        "statementpost" : {
+            "id" : "statementpost",
+            "type" : [
+                {
+                    "$ref" : "#statement"
+                },
+                {
+                    "type" : "array",
+                    "items" : {
+                        "$ref" : "#statement"
+                    }
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
jupiter-1 Research spike: schema validation of xAPI payloads

From some perfunctory tests, I think the z-schema library is pretty solid. I am going to use it to create a new schema starting with fugu13's schema to generate something that complies with draft 4 of the json-schema specification and successfully validates the 1.0.0 version of the xAPI specification.

If I am successful, I will port z-schema to Java. Ideally, the schema will be able to be verified using Jackson's streaming API, but that may be a tall order for this initial revision.
